### PR TITLE
Add hint for elm-ast parse error

### DIFF
--- a/src/TypeScript/Parser.elm
+++ b/src/TypeScript/Parser.elm
@@ -234,10 +234,17 @@ statementsForSingle sourceFile =
                 , inputStream.position |> toString
                 , errorMessages |> String.join "\n"
                 ]
-                    |> String.Interpolate.interpolate
-                        "Could not parse file `{0}` at position {1}. Errors:\n{2}"
+                    |> String.Interpolate.interpolate parseFailureErrorNotice
             )
 
+parseFailureErrorNotice : String
+parseFailureErrorNotice =
+  """Could not parse file `{0}` at position {1}. Errors:
+{2}
+
+There are some parsing bugs for the Elm AST library I use.
+Try reproducing the parse error by pasting it into:
+https://tunguski.github.io/elm-ast/example/."""
 
 type alias SourceFile =
     { path : String, contents : String }

--- a/src/TypeScript/Parser.elm
+++ b/src/TypeScript/Parser.elm
@@ -244,7 +244,9 @@ parseFailureErrorNotice =
 
 There are some parsing bugs for the Elm AST library I use.
 Try reproducing the parse error by pasting it into:
-https://tunguski.github.io/elm-ast/example/."""
+https://tunguski.github.io/elm-ast/example/.
+
+See this issue for a new Elm syntax parsing library that's being explored to fix some of these bugs: https://github.com/dillonkearns/elm-typescript-interop/issues/17."""
 
 type alias SourceFile =
     { path : String, contents : String }

--- a/tests-approval/expectError/invalidSyntax/output.approval.txt
+++ b/tests-approval/expectError/invalidSyntax/output.approval.txt
@@ -1,2 +1,6 @@
 Could not parse file `src/Main.elm` at position 32. Errors:
 expected end of input
+
+There are some parsing bugs for the Elm AST library I use.
+Try reproducing the parse error by pasting it into:
+https://tunguski.github.io/elm-ast/example/.

--- a/tests-approval/expectError/invalidSyntax/output.approval.txt
+++ b/tests-approval/expectError/invalidSyntax/output.approval.txt
@@ -4,3 +4,5 @@ expected end of input
 There are some parsing bugs for the Elm AST library I use.
 Try reproducing the parse error by pasting it into:
 https://tunguski.github.io/elm-ast/example/.
+
+See this issue for a new Elm syntax parsing library that's being explored to fix some of these bugs: https://github.com/dillonkearns/elm-typescript-interop/issues/17.


### PR DESCRIPTION
Inspired by: https://github.com/dillonkearns/elm-typescript-interop/issues/15.

Multi-line strings are a bit goofy, this is the best I could come up with 😬 