### PR TITLE
Add `prepare` script to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "elm-test",
     "approve": "./approve",
     "all": "npm test && ./approve",
-    "build": "npx elm-typescript-interop && webpack --mode production"
+    "build": "npx elm-typescript-interop && webpack --mode production",
+    "prepare": "npm run build"
   },
   "keywords": [
     "elm",


### PR DESCRIPTION
This commit adds a `prepare` script which performs the
build step so that users of `elm-typescript-interop` can invoke
the program with `npx` from source hosted by an arbitrary remote
git repository, instead of only being able to invoke the prebuilt
version distributed by the npm registry. This would allow users
to use unpublished versions, branches, or forks of
`elm-typescript-interop` with `npx` via [its support for passing a
git repository as an argument](https://github.com/npm/npx/tree/9a23db155b59a1b2b296c316d3401a15f0424967#invoking-a-command-from-a-github-repository)